### PR TITLE
Change target sdk to 35, so the plugin can be installed on android 15

### DIFF
--- a/setbox-plugin/app/build.gradle.kts
+++ b/setbox-plugin/app/build.gradle.kts
@@ -8,7 +8,7 @@ android {
     defaultConfig {
         applicationId = "com.yn.setbox.plugin"
         minSdk = 21
-        targetSdk = 22
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0" 
     }


### PR DESCRIPTION
Currently, if you want to install the plugin on android 15, you have to execute this command:

`pm install --bypass-low-target-sdk-block setbox-plugin-v1.0.0.apk`